### PR TITLE
require 'json/pure' might lead to JSON being loaded twice

### DIFF
--- a/lib/dm-types/json.rb
+++ b/lib/dm-types/json.rb
@@ -1,5 +1,5 @@
 require 'dm-core'
-require 'json/pure'
+require 'json/pure' unless defined? JSON
 
 module DataMapper
   class Property


### PR DESCRIPTION
Hi,

requiring 'json/pure' in the JSON Property might lead to JSON loaded twice, if the native version of the gem was already required before. This can lead to ugly warnings and arcane bugs such as this one:

http://prettystatemachine.blogspot.com/2010/09/typeerrors-in-tojson-make-me-briefly.html
