### PR TITLE
fixed an error after bcrypt-ruby update

### DIFF
--- a/lib/dm-types/bcrypt_hash.rb
+++ b/lib/dm-types/bcrypt_hash.rb
@@ -32,8 +32,3 @@ module DataMapper
     end # class BCryptHash
   end # class Property
 end # module DataMapper
-
-# The Bcrypt::Password#hash method returns a String and not an Integer,
-# which is required by any ruby class that uses a Hash underneath. Removing
-# this method does not cause any spec failures in Bcrypt::Password
-BCrypt::Password.class_eval { remove_method :hash }


### PR DESCRIPTION
in bcrypt-ruby the Password::hash method was renamed to #checksum - removing it caused an error
