### PR TITLE
Windows paths

### DIFF
--- a/lib/dm-types/file_path.rb
+++ b/lib/dm-types/file_path.rb
@@ -5,7 +5,7 @@ module DataMapper
   class Property
     class FilePath < String
 
-      length 255
+      length 260
 
       def primitive?(value)
         value.kind_of?(Pathname)


### PR DESCRIPTION
Increased the length of `FilePath` to 260 for Windows paths.

http://msdn.microsoft.com/en-us/library/aa365247%28v=vs.85%29.aspx#maxpath
