### PR TITLE
Add StringEnum type, which is similar to Enum, but different.

### DIFF
--- a/lib/dm-types.rb
+++ b/lib/dm-types.rb
@@ -15,6 +15,7 @@ module DataMapper
     autoload :ParanoidBoolean,    'dm-types/paranoid_boolean'
     autoload :ParanoidDateTime,   'dm-types/paranoid_datetime'
     autoload :Slug,               'dm-types/slug'
+    autoload :StringEnum,         'dm-types/string_enum'
     autoload :UUID,               'dm-types/uuid'
     autoload :URI,                'dm-types/uri'
     autoload :Yaml,               'dm-types/yaml'

--- a/lib/dm-types/string_enum.rb
+++ b/lib/dm-types/string_enum.rb
@@ -1,0 +1,59 @@
+require 'dm-core'
+require 'dm-types/support/flags'
+
+# A DataMapper::Property that stores one of a predefined list of strings
+# The list of allowed strings is defined in the call StringEnum[*allowed]
+# Differences from Enum:
+#   - primitive is String vs Integer (less efficient, more transparent)
+#   - durable against reordering (Enum will break existing records if reordered)
+module DataMapper
+  class Property
+    class StringEnum < String
+
+      include Flags
+
+      def initialize(model, name, options = {})
+        super
+
+        @flag_map = {}
+
+        flags = options.fetch(:flags, self.class.flags)
+        flags.each do |flag|
+          @flag_map[flag.to_s] = flag
+        end
+
+        if defined?(::DataMapper::Validations)
+          unless model.skip_auto_validation_for?(self)
+            if self.class.ancestors.include?(Property::StringEnum)
+              allowed = flag_map.values_at(*flag_map.keys.sort)
+              model.validates_within name, model.options_with_message({ :set => allowed }, self, :within)
+            end
+          end
+        end
+      end
+
+      def load(value)
+        flag_map[value]
+      end
+
+      def dump(value)
+        case value
+        when ::Array then value.collect { |v| dump(v) }
+        else              flag_map.invert[value]
+        end
+      end
+
+      def typecast(value)
+        return value if value.nil?
+        # Attempt to typecast using the class of the first item in the map.
+        case flag_map.values.first
+        when ::Symbol then value.to_sym
+        when ::String then value.to_s
+        when ::Fixnum then value.to_i
+        else               value
+        end
+      end
+
+    end # class StringEnum
+  end # class Property
+end # module DataMapper

--- a/spec/unit/string_enum_spec.rb
+++ b/spec/unit/string_enum_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+try_spec do
+  describe DataMapper::Property::StringEnum do
+    before :all do
+      class ::User
+        include DataMapper::Resource
+        property :id, Serial
+      end
+
+      @property_klass = DataMapper::Property::StringEnum
+    end
+
+    it_should_behave_like "A property with flags"
+
+    describe '.dump' do
+      before do
+        @enum = User.property(:enum, DataMapper::Property::StringEnum[:first, :second, :third])
+      end
+
+      it 'should return the key of the value match from the flag map' do
+        @enum.dump(:first).should == "first"
+        @enum.dump(:second).should == "second"
+        @enum.dump(:third).should == "third"
+      end
+
+      describe 'when there is no match' do
+        it 'should return nil' do
+          @enum.dump(:zero).should be_nil
+        end
+      end
+    end
+
+    describe '.load' do
+      before do
+        @enum = User.property(:enum, DataMapper::Property::StringEnum, :flags => [:uno, :dos, :tres])
+      end
+
+      it 'returns the value of the key match from the flag map' do
+        @enum.load("uno").should == :uno
+        @enum.load("dos").should == :dos
+        @enum.load("tres").should == :tres
+      end
+
+      describe 'when there is no key' do
+        it 'returns nil' do
+          @enum.load(-1).should be_nil
+        end
+      end
+    end
+
+    describe '.typecast' do
+      describe 'of StringEnum created from a symbol' do
+        before :all do
+          @enum = User.property(:enum, DataMapper::Property::StringEnum, :flags => [:uno])
+        end
+
+        describe 'when given a symbol' do
+          it 'uses StringEnum type' do
+            @enum.typecast(:uno).should == :uno
+          end
+        end
+
+        describe 'when given a string' do
+          it 'uses StringEnum type' do
+            @enum.typecast('uno').should == :uno
+          end
+        end
+
+        describe 'when given nil' do
+          it 'returns nil' do
+            @enum.typecast(nil).should == nil
+          end
+        end
+      end
+
+      describe 'of StringEnum created from a string' do
+        before :all do
+          @enum = User.property(:enum, DataMapper::Property::StringEnum, :flags => ['uno'])
+        end
+
+        describe 'when given a symbol' do
+          it 'uses StringEnum type' do
+            @enum.typecast(:uno).should == 'uno'
+          end
+        end
+
+        describe 'when given a string' do
+          it 'uses StringEnum type' do
+            @enum.typecast('uno').should == 'uno'
+          end
+        end
+
+        describe 'when given nil' do
+          it 'returns nil' do
+            @enum.typecast(nil).should == nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a new Flag-based Property, because the existing Enum Property:
- is transparent in Ruby, but opaque to other applications that share the same data-store
- breaks existing resources when reordered

Newly added StringEnum Property:
- is transparent in Ruby, and transparent to other applications using the same data-store
- does not break existing resources when reordered

Please let me know if there's anything in particular I should do to clean this up or make it suitable for inclusion. Also please let me know if this just isn't appropriate for inclusion in dm-types.

Thank you,
Emmanuel
