### PR TITLE
Make paranoid properties STI-aware

### DIFF
--- a/lib/dm-types/paranoid/base.rb
+++ b/lib/dm-types/paranoid/base.rb
@@ -45,7 +45,7 @@ module DataMapper
 
         # @api private
         def paranoid_properties
-          @paranoid_properties
+          @paranoid_properties || base_model.paranoid_properties
         end
 
         # @api private


### PR DESCRIPTION
Make paranoid properties STI-aware so you can properly destroy them.  Fixes #15

(`destroy` blows up on `model.paranoid_properties.each` in `paranoid_destroy` otherwise)
