### PR TITLE
Fix breakage introduced by my changes to dm-validations

### DIFF
--- a/lib/dm-types/enum.rb
+++ b/lib/dm-types/enum.rb
@@ -18,7 +18,7 @@ module DataMapper
         end
 
         if defined?(::DataMapper::Validations)
-          unless model.skip_auto_validation_for?(self)
+          unless ::DataMapper::Validations::AutoValidations.skip_auto_validation_for?(self)
             allowed = flag_map.values_at(*flag_map.keys.sort)
             model.validates_within name, model.options_with_message({ :set => allowed }, self, :within)
           end


### PR DESCRIPTION
Change in dm-validations was to an `@api private` method, but I don't see how to remove the coupling between dm-types and dm-validations without invasive changes.

This is the minimal change to unbreak dm-types, for now. A better long-term solution would be good.
