### PR TITLE
Be more flexible about type-casting string integers in EpochTime

### DIFF
--- a/lib/dm-types/epoch_time.rb
+++ b/lib/dm-types/epoch_time.rb
@@ -5,7 +5,7 @@ module DataMapper
     class EpochTime < Integer
 
       def load(value)
-        if value.kind_of?(::Numeric)
+        if value.kind_of?(::Numeric) || value =~ /^\d+$/
           ::Time.at(value.to_i)
         else
           value
@@ -15,6 +15,7 @@ module DataMapper
       def dump(value)
         case value
           when ::Numeric, ::Time then value.to_i
+          when /^\d+$/           then value.to_i
           when ::DateTime        then datetime_to_time(value).to_i
         end
       end

--- a/spec/unit/epoch_time_spec.rb
+++ b/spec/unit/epoch_time_spec.rb
@@ -32,6 +32,12 @@ describe DataMapper::Property::EpochTime do
 
       it { should == value }
     end
+    
+    describe 'with a UNIX time string' do
+      let(:value) { Time.now.to_i.to_s }
+
+      it { should == value.to_i }
+    end
 
     describe 'with nil' do
       let(:value) { nil }
@@ -47,6 +53,12 @@ describe DataMapper::Property::EpochTime do
       let(:value) { Time.now.to_i }
 
       it { should == Time.at(value) }
+    end
+    
+    describe 'with a UNIX time string' do
+      let(:value) { Time.now.to_i.to_s }
+
+      it { should == Time.at(value.to_i) }
     end
 
     describe 'with nil' do


### PR DESCRIPTION
This just allows the loading and dumping of strings like "1309698505".  This makes it easier to work with data sources that might not strictly encode timestamps as integers, and also with dm-aggregates, which returns strings via the `#aggregate` method.
