### PR TITLE
Prevent DirtyMinder from attempting to wrap nil values.

### DIFF
--- a/lib/dm-types/support/dirty_minder.rb
+++ b/lib/dm-types/support/dirty_minder.rb
@@ -137,17 +137,17 @@ module DataMapper
 
       # This catches any direct assignment, allowing us to hook the Hash or Array.
       def set(resource, value)
-        hook_value(resource, value) unless value.frozen? || value.kind_of?(Hooker)
+        hook_value(resource, value) unless value.nil? || value.kind_of?(Hooker)
         super
       end
 
       # This gets called when Resource#reload is called (instead of #set).
       def set!(resource, value)
-        hook_value(resource, value) unless value.frozen? || value.kind_of?(Hooker)
+        hook_value(resource, value) unless value.nil? || value.kind_of?(Hooker)
         super
       end
 
-      private
+    private
 
       def hook_value(resource, value)
         return if value.kind_of? Hooker


### PR DESCRIPTION
This happens when a resource is lazy-loading a property that includes `DirtyMinder`: `Resource#eager_load` iterates over the set of properties to lazy-load and calls `Property#set` with `nil` for each before calling `Collection#lazy_load`. The `Property#set` call blows up when given nil because `DirtyMinder` tries to add instance variables to nil in `DirtyMinder#wrap_value`—`@resource` & `@property`. `nil`, of course, is a frozen object and thus the attempt to add instance variables blows up.   

Do the research if you don't believe me :P. Seriously, please do; I'd love to be proven wrong about this. Anyways, `nil` can't be mutated, thus I don't think anyone cares about tracking `nil`, so this fix/work-around should not impact functionality at all.

/cc @jpr5
