### PR TITLE
Updating multi_json, & stringext dependencies to be more modern.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Gemfile.*
 
 ## PROJECT::SPECIFIC
 spec/db/
+
+## NETBEANS
+/nbproject

--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('bcrypt-ruby', '~> 3.0.0')
   gem.add_runtime_dependency('fastercsv',   '~> 1.5.4')
   gem.add_runtime_dependency('multi_json', '>= 1.7.7')
-  gem.add_runtime_dependency('stringex', '>= 2.0.3')
+  gem.add_runtime_dependency('stringex', '>= 2.0.8')
   gem.add_runtime_dependency('uuidtools',   '~> 2.1.2')
 
   gem.add_development_dependency('rake',  '~> 0.9.2')

--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('dm-core',     '~> 1.3.0.beta')
   gem.add_runtime_dependency('bcrypt-ruby', '~> 3.0.0')
   gem.add_runtime_dependency('fastercsv',   '~> 1.5.4')
-  gem.add_runtime_dependency('multi_json',  '~> 1.3.2')
-  gem.add_runtime_dependency('stringex',    '~> 1.4')
+  gem.add_runtime_dependency('multi_json', '>= 1.7.7')
+  gem.add_runtime_dependency('stringex', '>= 2.0.3')
   gem.add_runtime_dependency('uuidtools',   '~> 2.1.2')
 
   gem.add_development_dependency('rake',  '~> 0.9.2')


### PR DESCRIPTION
updating dependencies for multi_json, and stringsext. All specs pass. This is a must for locomotivecms compatibility.