### PR TITLE
Update safe_yaml to latest stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'bcrypt-ruby', '~> 3.0'
 gem 'fastercsv',   '~> 1.5'
 gem 'multi_json',  '~> 1.0'
 gem 'json',        '~> 1.6', :platforms => [ :ruby_18 ]
-gem 'safe_yaml',   '~> 0.7.0'
+gem 'safe_yaml',   '~> 0.9.7'
 gem 'stringex',    '~> 1.4'
 gem 'uuidtools',   '~> 2.1'
 


### PR DESCRIPTION
This is the simplest way I could see to make this change (though I've noted that in `dm_types` master branch `safe_yaml` is actually gone, so if it's preferable to just remove the requirement let me know).

I found that running bundle on the branch fails due to `dm-migrations` not being found, but this issue pre-exists this change.

It looks like this, for reference:
```
Fetching gem metadata from http://rubygems.org/.........
Fetching gem metadata from http://rubygems.org/..
Resolving dependencies...
Could not find gem 'dm-migrations (~> 1.2.0) ruby' in http://github.com/datamapper/dm-migrations.git (at master).
Source contains 'dm-migrations' at: 1.3.0.beta
```