### PR TITLE
DirtyMinder should not extend NilClass

### DIFF
--- a/lib/dm-types/support/dirty_minder.rb
+++ b/lib/dm-types/support/dirty_minder.rb
@@ -148,7 +148,10 @@ module DataMapper
 
       # Catch any direct assignment (#set), and any Resource#reload (set!).
       def set!(resource, value)
-        hook_value(resource, value) unless value.kind_of? Hooker
+        # Do not extend non observed value classes 
+        if Hooker::MUTATION_METHODS.keys.detect { |klass| value.kind_of?(klass) }
+          hook_value(resource, value) unless value.kind_of? Hooker
+        end
         super
       end
 

--- a/lib/dm-types/yaml.rb
+++ b/lib/dm-types/yaml.rb
@@ -22,6 +22,8 @@ module DataMapper
       end
 
       def dump(value)
+        value = ::String.new(value) if value.kind_of?(::String)
+        #p value.object_id if value.kind_of?(::String)
         if value.nil?
           nil
         elsif value.is_a?(::String) && value =~ /^---/

--- a/lib/dm-types/yaml.rb
+++ b/lib/dm-types/yaml.rb
@@ -22,8 +22,6 @@ module DataMapper
       end
 
       def dump(value)
-        value = ::String.new(value) if value.kind_of?(::String)
-        #p value.object_id if value.kind_of?(::String)
         if value.nil?
           nil
         elsif value.is_a?(::String) && value =~ /^---/

--- a/spec/integration/yaml_spec.rb
+++ b/spec/integration/yaml_spec.rb
@@ -64,6 +64,24 @@ try_spec do
           end
         end
       end
+
+      describe 'with invetions as a string' do
+        before :all do
+          object = "Foo and Bar" #.freeze
+          @resource.inventions = object
+        end
+
+        describe 'when dumpoed and loaded again' do
+          before :all do
+            @resource.save.should be(true)
+            @resource.reload
+          end
+
+          it 'has correct invetions' do
+            @resource.inventions.should == 'Foo and Bar'
+          end
+        end
+      end
     end
   end
 end

--- a/spec/integration/yaml_spec.rb
+++ b/spec/integration/yaml_spec.rb
@@ -65,19 +65,19 @@ try_spec do
         end
       end
 
-      describe 'with invetions as a string' do
+      describe 'with inventions as a string' do
         before :all do
           object = "Foo and Bar" #.freeze
           @resource.inventions = object
         end
 
-        describe 'when dumpoed and loaded again' do
+        describe 'when dumped and loaded again' do
           before :all do
             @resource.save.should be(true)
             @resource.reload
           end
 
-          it 'has correct invetions' do
+          it 'has correct inventions' do
             @resource.inventions.should == 'Foo and Bar'
           end
         end

--- a/spec/unit/dirty_minder_spec.rb
+++ b/spec/unit/dirty_minder_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'dm-types/support/dirty_minder'
+
+describe DataMapper::Property::DirtyMinder,'set!' do
+
+  let(:property_class) do
+    Class.new(DataMapper::Property::Object) do
+      include DataMapper::Property::DirtyMinder
+    end
+  end
+
+  let(:model) do
+    property_class = self.property_class
+    Class.new do
+      include DataMapper::Resource
+      property :id,DataMapper::Property::Serial
+      property :name,property_class
+
+      def self.name; 'FredsClass'; end
+    end
+  end
+
+  let(:resource) { model.new }
+
+  let(:object) { model.properties[:name] }
+
+  subject { object.set!(resource,value) }
+
+  shared_examples_for 'a non hooked value' do
+    it 'should not extend value with hook' do
+      value.should_not be_kind_of(DataMapper::Property::DirtyMinder::Hooker)
+    end
+  end
+
+  shared_examples_for 'a hooked value' do
+    it 'should extend value with hook' do
+      value.should be_kind_of(DataMapper::Property::DirtyMinder::Hooker)
+    end
+  end
+
+  before do
+    subject
+  end
+
+  context 'when setting nil' do
+    let(:value) { nil }
+    it_should_behave_like 'a non hooked value'
+  end
+
+  context 'when setting a String' do
+    let(:value) { "The fred" }
+    it_should_behave_like 'a non hooked value'
+  end
+
+  context 'when setting an Array' do
+    let(:value) { ["The fred"] }
+    it_should_behave_like 'a hooked value'
+  end
+
+  context 'when setting a Hash' do
+    let(:value) { {"The" => "fred"} }
+    it_should_behave_like 'a hooked value'
+  end
+end


### PR DESCRIPTION
Can PR #50 be back ported to the `release-1.2` branch?  When using DataMapper with Passenger, Passenger sometimes freezes the `nil` value (see https://code.google.com/p/phusion-passenger/issues/detail?id=1093).  When `DirtyMinder` tries to track a frozen nil value, an error can occur:

```
/Users/bturner/.rvm/gems/ruby-2.1.2@ghnproxy/gems/dm-types-1.2.2/lib/dm-types/support/dirty_minder.rb:144:in `track': can't modify frozen object (RuntimeError)
	from /Users/bturner/.rvm/gems/ruby-2.1.2@ghnproxy/gems/dm-types-1.2.2/lib/dm-types/support/dirty_minder.rb:161:in `hook_value'
	from /Users/bturner/.rvm/gems/ruby-2.1.2@ghnproxy/gems/dm-types-1.2.2/lib/dm-types/support/dirty_minder.rb:151:in `set!'
	from /Users/bturner/.rvm/gems/ruby-2.1.2@ghnproxy/gems/dm-core-1.2.1/lib/dm-core/property.rb:625:in `set'
	from /Users/bturner/.rvm/gems/ruby-2.1.2@ghnproxy/gems/dm-core-1.2.1/lib/dm-core/resource/persistence_state.rb:22:in `set'
	from /Users/bturner/.rvm/gems/ruby-2.1.2@ghnproxy/gems/dm-core-1.2.1/lib/dm-core/resource/persistence_state/transient.rb:14:in `set'
	from /Users/bturner/.rvm/gems/ruby-2.1.2@ghnproxy/gems/dm-core-1.2.1/lib/dm-core/model/property.rb:238:in `headers='
	from test.rb:19:in `<main>'
```

PR #50 limited extending classes with `Hooker` to only certain classes.  It would be awesome to back port this fix into 1.2.x.

This PR simply cherry-picks mbj's fixes to `release-1.2`.