### PR TITLE
Change dependency from bcrypt-ruby to bcrypt

### DIFF
--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -16,12 +16,12 @@ Gem::Specification.new do |gem|
   gem.require_paths = [ "lib" ]
   gem.version       = DataMapper::Types::VERSION
 
-  gem.add_runtime_dependency('dm-core',     '~> 1.3.0.beta')
-  gem.add_runtime_dependency('bcrypt-ruby', '~> 3.0.0')
-  gem.add_runtime_dependency('fastercsv',   '~> 1.5.4')
-  gem.add_runtime_dependency('multi_json',  '~> 1.3.2')
-  gem.add_runtime_dependency('stringex',    '~> 1.4')
-  gem.add_runtime_dependency('uuidtools',   '~> 2.1.2')
+  gem.add_runtime_dependency('dm-core',    '~> 1.3.0.beta')
+  gem.add_runtime_dependency('bcrypt',     '~> 3.0.0')
+  gem.add_runtime_dependency('fastercsv',  '~> 1.5.4')
+  gem.add_runtime_dependency('multi_json', '~> 1.3.2')
+  gem.add_runtime_dependency('stringex',   '~> 1.4')
+  gem.add_runtime_dependency('uuidtools',  '~> 2.1.2')
 
   gem.add_development_dependency('rake',  '~> 0.9.2')
   gem.add_development_dependency('rspec', '~> 1.3.2')


### PR DESCRIPTION
The `bcrypt-ruby` gem is now known simply as `bcrypt`. Upon installation of dm-types as is a warning message is produced requesting that the dependency is appropriately renamed. This file change does so.
