### PR TITLE
Change dependency from bcrypt-ruby to bcrypt

### DIFF
--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -15,14 +15,14 @@ Gem::Specification.new do |gem|
   gem.require_paths = [ "lib" ]
   gem.version       = '1.2.2'
 
-  gem.add_runtime_dependency('bcrypt-ruby', '~> 3.0')
-  gem.add_runtime_dependency('fastercsv',   '~> 1.5')
-  gem.add_runtime_dependency('multi_json',  '~> 1.0')
-  gem.add_runtime_dependency('json',        '~> 1.6')
-  gem.add_runtime_dependency('safe_yaml',   '~> 0.6.1')
-  gem.add_runtime_dependency('stringex',    '~> 1.4')
-  gem.add_runtime_dependency('uuidtools',   '~> 2.1')
-  gem.add_runtime_dependency('dm-core',     '~> 1.2.0')
+  gem.add_runtime_dependency('bcrypt',     '~> 3.0')
+  gem.add_runtime_dependency('fastercsv',  '~> 1.5')
+  gem.add_runtime_dependency('multi_json', '~> 1.0')
+  gem.add_runtime_dependency('json',       '~> 1.6')
+  gem.add_runtime_dependency('safe_yaml',  '~> 0.6.1')
+  gem.add_runtime_dependency('stringex',   '~> 1.4')
+  gem.add_runtime_dependency('uuidtools',  '~> 2.1')
+  gem.add_runtime_dependency('dm-core',    '~> 1.2.0')
 
   gem.add_development_dependency('rake',  '~> 0.9')
   gem.add_development_dependency('rspec', '~> 1.3')


### PR DESCRIPTION
The `bcrypt-ruby` gem is now known simply as `bcrypt`. Upon installation of `dm-types` as is a warning message is produced requesting that the dependency is appropriately renamed. This file change does so.