### PR TITLE
Cast empty string to nil in enum

### DIFF
--- a/lib/dm-types/enum.rb
+++ b/lib/dm-types/enum.rb
@@ -40,7 +40,12 @@ module DataMapper
         # Attempt to typecast using the class of the first item in the map.
         case flag_map[1]
         when ::Symbol then value.to_sym
-        when ::String then value.to_s
+        when ::String then 
+          if !value.empty?
+            value.to_s
+          else
+            nil
+          end
         when ::Fixnum then value.to_i
         else               value
         end


### PR DESCRIPTION
When using webforms we do have empty Strings quite often as a result in optional Selects. This pr fixes the exception in Datamapper