### PR TITLE
Normalize URIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 bundler_args: --without yard guard metrics benchmarks
 before_install:
   - gem install bundler --pre
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq postgresql-server-dev-9.3
 branches:
   only:
     - /^release-.*$/
@@ -15,30 +17,22 @@ before_script:
   - psql  -c "create database datamapper_alternate_tests;" -U postgres
 script: "bundle exec rake spec"
 rvm:
-  - ree
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.5
   - ruby-head
-  - jruby-18mode
   - jruby-19mode
   - jruby-head
-  - rbx-18mode
-  - rbx-19mode
+  - rbx-2
 env:
   - "GIT_BRANCH=release-1.2 ADAPTER=in_memory"
   - "GIT_BRANCH=release-1.2 ADAPTER=yaml"
   - "GIT_BRANCH=release-1.2 ADAPTER=sqlite"
   - "GIT_BRANCH=release-1.2 ADAPTER=mysql DM_DB_USER=root DM_DB_PASSWORD=''"
   - "GIT_BRANCH=release-1.2 ADAPTER=postgres DM_DB_USER=postgres DM_DB_PASSWORD=''"
-notifications:
-  irc: "irc.freenode.org#datamapper"
-  email:
-    - dan.kubb@gmail.com
-    
 matrix:
   allow_failures:
-    - rvm: rbx-18mode
-    - rvm: rbx-19mode
-      env: "GIT_BRANCH=release-1.2 ADAPTER=yaml"
+    - rvm: 2.2.0
+    - rvm: ruby-head
+    - rvm: jruby-head
+    - rvm: rbx-2

--- a/lib/dm-types/uri.rb
+++ b/lib/dm-types/uri.rb
@@ -22,7 +22,8 @@ module DataMapper
       end
 
       def load(value)
-        Addressable::URI.parse(value)
+        uri = Addressable::URI.parse(value)
+        uri.normalize unless uri.nil?
       end
 
       def dump(value)

--- a/lib/dm-types/uri.rb
+++ b/lib/dm-types/uri.rb
@@ -7,7 +7,7 @@ module DataMapper
 
       # Maximum length chosen based on recommendation:
       # http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-an-url
-      length 2000
+      length 2083
 
       def custom?
         true

--- a/lib/dm-types/uri.rb
+++ b/lib/dm-types/uri.rb
@@ -26,7 +26,7 @@ module DataMapper
       end
 
       def dump(value)
-        value.to_s unless value.nil?
+        value.to_str unless value.nil?
       end
 
       def typecast_to_primitive(value)

--- a/spec/integration/uri_spec.rb
+++ b/spec/integration/uri_spec.rb
@@ -106,8 +106,8 @@ try_spec do
               resource.reload
             end
 
-            it 'has the same original URI' do
-              resource.uri.to_s.should eql(uri)
+            it 'matches a normalized form of the original URI' do
+              resource.uri.should eql(Addressable::URI.parse(uri).normalize)
             end
           end
         end

--- a/spec/integration/uri_spec.rb
+++ b/spec/integration/uri_spec.rb
@@ -1,135 +1,113 @@
 require 'spec_helper'
 
 try_spec do
-
   require './spec/fixtures/bookmark'
 
   describe DataMapper::TypesFixtures::Bookmark do
     supported_by :all do
-      describe 'without URI' do
-        before :all do
-          @uri = nil
-          @resource = DataMapper::TypesFixtures::Bookmark.new(
-            :title  => 'Check this out',
-            :uri    => @uri,
-            :shared => false,
-            :tags   => %w[ misc ]
-          )
+      before :all do
+        DataMapper::TypesFixtures::Bookmark.auto_migrate!
+      end
 
-          @resource.save.should be(true)
-        end
+      let(:resource) do
+        DataMapper::TypesFixtures::Bookmark.create(
+          :title  => 'Check this out',
+          :uri    => uri,
+          :shared => false,
+          :tags   => %w[ misc ]
+        )
+      end
+
+      before do
+        resource.should be_saved
+      end
+
+      context 'without URI' do
+        let(:uri) { nil }
 
         it 'can be found by uri' do
-          DataMapper::TypesFixtures::Bookmark.first(:uri => @uri).should == @resource
+          DataMapper::TypesFixtures::Bookmark.first(:uri => uri).should eql(resource)
         end
 
         describe 'when reloaded' do
-          before :all do
-            @resource.reload
+          before do
+            resource.reload
           end
 
           it 'has no uri' do
-            @resource.uri.should be_nil
+            resource.uri.should be(nil)
           end
         end
       end
 
       describe 'with a blank URI' do
-        before :all do
-          @uri = ''
-          DataMapper::TypesFixtures::Bookmark.auto_migrate!
-          @resource = DataMapper::TypesFixtures::Bookmark.new(
-            :title  => 'Check this out',
-            :uri    => @uri,
-            :shared => false,
-            :tags   => %w[ misc ]
-          )
-
-          @resource.save.should be(true)
-        end
+        let(:uri) { '' }
 
         it 'can be found by uri' do
-          DataMapper::TypesFixtures::Bookmark.first(:uri => @uri).should == @resource
+          DataMapper::TypesFixtures::Bookmark.first(:uri => uri).should eql(resource)
         end
 
         describe 'when reloaded' do
-          before :all do
-            @resource.reload
+          before do
+            resource.reload
           end
 
           it 'is loaded as URI object' do
-            @resource.uri.should be_an_instance_of(Addressable::URI)
+            resource.uri.should be_an_instance_of(Addressable::URI)
           end
 
           it 'has the same original URI' do
-            @resource.uri.to_s.should == @uri
+            resource.uri.to_s.should eql(uri)
           end
         end
       end
 
       describe 'with invalid URI' do
-        before :all do
-          @uri = 'this is def. not URI'
-          @resource = DataMapper::TypesFixtures::Bookmark.new(
-            :title  => 'Check this out',
-            :uri    => @uri,
-            :shared => false,
-            :tags   => %w[ misc ]
-          )
-        end
+        let(:uri) { 'this is def. not URI' }
 
         it 'is perfectly valid (URI type does not provide auto validations)' do
-          @resource.save.should be(true)
+          resource.save.should be(true)
         end
       end
 
       %w[
-      http://apple.com
-      http://www.apple.com
-      http://apple.com/
-      http://apple.com/iphone
-      http://www.google.com/search?client=safari&rls=en-us&q=LED&ie=UTF-8&oe=UTF-8
-      http://books.google.com
-      http://books.google.com/
-      http://db2.clouds.megacorp.net:8080
-      https://github.com
-      https://github.com/
-      http://www.example.com:8088/never/ending/path/segments/
-      http://db2.clouds.megacorp.net:8080/resources/10
-      http://www.example.com:8088/never/ending/path/segments
-      http://books.google.com/books?id=uSUJ3VhH4BsC&printsec=frontcover&dq=subject:%22+Linguistics+%22&as_brr=3&ei=DAHPSbGQE5rEzATk1sShAQ&rview=1
-      http://books.google.com:80/books?uid=14472359158468915761&rview=1
-      http://books.google.com/books?id=Ar3-TXCYXUkC&printsec=frontcover&rview=1
-      http://books.google.com/books/vp6ae081e454d30f89b6bca94e0f96fc14.js
-      http://www.google.com/images/cleardot.gif
-      http://books.google.com:80/books?id=Ar3-TXCYXUkC&printsec=frontcover&rview=1#PPA5,M1
-      http://www.hulu.com/watch/64923/terminator-the-sarah-connor-chronicles-to-the-lighthouse
-      http://hulu.com:80/browse/popular/tv
-      http://www.hulu.com/watch/62475/the-simpsons-gone-maggie-gone#s-p1-so-i0
+        http://apple.com
+        http://www.apple.com
+        http://apple.com/
+        http://apple.com/iphone
+        http://www.google.com/search?client=safari&rls=en-us&q=LED&ie=UTF-8&oe=UTF-8
+        http://books.google.com
+        http://books.google.com/
+        http://db2.clouds.megacorp.net:8080
+        https://github.com
+        https://github.com/
+        http://www.example.com:8088/never/ending/path/segments/
+        http://db2.clouds.megacorp.net:8080/resources/10
+        http://www.example.com:8088/never/ending/path/segments
+        http://books.google.com/books?id=uSUJ3VhH4BsC&printsec=frontcover&dq=subject:%22+Linguistics+%22&as_brr=3&ei=DAHPSbGQE5rEzATk1sShAQ&rview=1
+        http://books.google.com:80/books?uid=14472359158468915761&rview=1
+        http://books.google.com/books?id=Ar3-TXCYXUkC&printsec=frontcover&rview=1
+        http://books.google.com/books/vp6ae081e454d30f89b6bca94e0f96fc14.js
+        http://www.google.com/images/cleardot.gif
+        http://books.google.com:80/books?id=Ar3-TXCYXUkC&printsec=frontcover&rview=1#PPA5,M1
+        http://www.hulu.com/watch/64923/terminator-the-sarah-connor-chronicles-to-the-lighthouse
+        http://hulu.com:80/browse/popular/tv
+        http://www.hulu.com/watch/62475/the-simpsons-gone-maggie-gone#s-p1-so-i0
       ].each do |uri|
         describe "with URI set to '#{uri}'" do
-          before :all do
-            @resource = DataMapper::TypesFixtures::Bookmark.new(
-              :title  => 'Check this out',
-              :uri    => uri,
-              :shared => false,
-              :tags   => %w[ misc ]
-            )
-
-            @resource.save.should be(true)
-          end
+          let(:uri) { uri }
 
           it 'can be found by uri' do
-            DataMapper::TypesFixtures::Bookmark.first(:uri => uri).should_not be_nil
+            DataMapper::TypesFixtures::Bookmark.first(:uri => uri).should_not be(nil)
           end
 
           describe 'when reloaded' do
-            before :all do
-              @resource.reload
+            before do
+              resource.reload
             end
 
             it 'has the same original URI' do
-              @resource.uri.to_s.should eql(uri)
+              resource.uri.to_s.should eql(uri)
             end
           end
         end

--- a/spec/unit/uri_spec.rb
+++ b/spec/unit/uri_spec.rb
@@ -49,6 +49,15 @@ try_spec do
           subject.load('').should eql(Addressable::URI.parse(''))
         end
       end
+
+      context 'with a non-normalized URI' do
+        let(:uri_str) { 'http://www.example.com:80'                       }
+        let(:uri)     { Addressable::URI.parse('http://www.example.com/') }
+
+        it 'returns the URI as a normalized Addressable::URI' do
+          subject.load(uri_str).should eql(uri)
+        end
+      end
     end
 
     describe '.typecast' do

--- a/spec/unit/uri_spec.rb
+++ b/spec/unit/uri_spec.rb
@@ -4,59 +4,69 @@ require './spec/fixtures/bookmark'
 
 try_spec do
   describe DataMapper::Property::URI do
-    before do
-      @uri_str = 'http://example.com/path/to/resource/'
-      @uri     = Addressable::URI.parse(@uri_str)
+    subject { DataMapper::TypesFixtures::Bookmark.properties[:uri] }
 
-      @property = DataMapper::TypesFixtures::Bookmark.properties[:uri]
-    end
+    let(:uri)     { Addressable::URI.parse(uri_str)        }
+    let(:uri_str) { 'http://example.com/path/to/resource/' }
+
+    it { should be_instance_of(described_class) }
 
     describe '.dump' do
-      it 'returns the URI as a String' do
-        @property.dump(@uri).should eql(@uri_str)
-      end
-
-      describe 'when given nil' do
-        it 'returns nil' do
-          @property.dump(nil).should be(nil)
+      context 'with an instance of Addressable::URI' do
+        it 'returns the URI as a String' do
+          subject.dump(uri).should eql(uri_str)
         end
       end
 
-      describe 'when given an empty string' do
+      context 'with nil' do
+        it 'returns nil' do
+          subject.dump(nil).should be(nil)
+        end
+      end
+
+      context 'with an empty string' do
         it 'returns an empty URI' do
-          @property.dump('').should eql('')
+          subject.dump('').should eql('')
         end
       end
     end
 
     describe '.load' do
-      it 'returns the URI as Addressable' do
-        @property.load(@uri_str).should eql(@uri)
-      end
-
-      describe 'when given nil' do
-        it 'returns nil' do
-          @property.load(nil).should be(nil)
+      context 'with a string' do
+        it 'returns the URI as an Addressable::URI' do
+          subject.load(uri_str).should eql(uri)
         end
       end
 
-      describe 'if given an empty String' do
+      context 'with nil' do
+        it 'returns nil' do
+          subject.load(nil).should be(nil)
+        end
+      end
+
+      context 'with an empty string' do
         it 'returns an empty URI' do
-          @property.load('').should eql(Addressable::URI.parse(''))
+          subject.load('').should eql(Addressable::URI.parse(''))
         end
       end
     end
 
     describe '.typecast' do
-      describe 'given instance of Addressable::URI' do
+      context 'with an instance of Addressable::URI' do
         it 'does nothing' do
-          @property.typecast(@uri).should eql(@uri)
+          subject.typecast(uri).should eql(uri)
         end
       end
 
-      describe 'when given a string' do
+      context 'with a string' do
         it 'delegates to .load' do
-          @property.typecast(@uri_str).should eql(@uri)
+          subject.typecast(uri_str).should eql(uri)
+        end
+      end
+
+      context 'with nil' do
+        it 'returns nil' do
+          subject.typecast(nil).should be(nil)
         end
       end
     end

--- a/spec/unit/uri_spec.rb
+++ b/spec/unit/uri_spec.rb
@@ -13,36 +13,36 @@ try_spec do
 
     describe '.dump' do
       it 'returns the URI as a String' do
-        @property.dump(@uri).should == @uri_str
+        @property.dump(@uri).should eql(@uri_str)
       end
 
       describe 'when given nil' do
         it 'returns nil' do
-          @property.dump(nil).should be_nil
+          @property.dump(nil).should be(nil)
         end
       end
 
       describe 'when given an empty string' do
         it 'returns an empty URI' do
-          @property.dump('').should == ''
+          @property.dump('').should eql('')
         end
       end
     end
 
     describe '.load' do
       it 'returns the URI as Addressable' do
-        @property.load(@uri_str).should == @uri
+        @property.load(@uri_str).should eql(@uri)
       end
 
       describe 'when given nil' do
         it 'returns nil' do
-          @property.load(nil).should be_nil
+          @property.load(nil).should be(nil)
         end
       end
 
       describe 'if given an empty String' do
         it 'returns an empty URI' do
-          @property.load('').should == Addressable::URI.parse('')
+          @property.load('').should eql(Addressable::URI.parse(''))
         end
       end
     end
@@ -50,13 +50,13 @@ try_spec do
     describe '.typecast' do
       describe 'given instance of Addressable::URI' do
         it 'does nothing' do
-          @property.typecast(@uri).should == @uri
+          @property.typecast(@uri).should eql(@uri)
         end
       end
 
       describe 'when given a string' do
         it 'delegates to .load' do
-          @property.typecast(@uri_str).should == @uri
+          @property.typecast(@uri_str).should eql(@uri)
         end
       end
     end


### PR DESCRIPTION
This branch changes the URI type to normalize the URI before it is stored in the database.

It also fixes the length to match the current known maximum length for a URI and refactors the URI specs to use a more modern style.