### PR TITLE
Update dm-types.gemspec

### DIFF
--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[lib]
   gem.version       = DataMapper::Types::VERSION
 
-  gem.add_runtime_dependency('bcrypt', '~> 3.0.0')
+  gem.add_runtime_dependency('bcrypt')
   gem.add_runtime_dependency('dm-core',     '~> 1.2.0')
   gem.add_runtime_dependency('fastercsv',   '~> 1.5.4')
   gem.add_runtime_dependency('multi_json',  '~> 1.3.2')

--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[lib]
   gem.version       = DataMapper::Types::VERSION
 
-  gem.add_runtime_dependency('bcrypt-ruby', '~> 3.0.0')
+  gem.add_runtime_dependency('bcrypt', '~> 3.0.0')
   gem.add_runtime_dependency('dm-core',     '~> 1.3.0.beta')
   gem.add_runtime_dependency('fastercsv',   '~> 1.5.4')
   gem.add_runtime_dependency('multi_json',  '~> 1.3.2')

--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = DataMapper::Types::VERSION
 
   gem.add_runtime_dependency('bcrypt', '~> 3.0.0')
-  gem.add_runtime_dependency('dm-core',     '~> 1.3.0.beta')
+  gem.add_runtime_dependency('dm-core',     '~> 1.2.0')
   gem.add_runtime_dependency('fastercsv',   '~> 1.5.4')
   gem.add_runtime_dependency('multi_json',  '~> 1.3.2')
   gem.add_runtime_dependency('safe_yaml',   '~> 0.6.1')

--- a/lib/dm-types/version.rb
+++ b/lib/dm-types/version.rb
@@ -1,5 +1,5 @@
 module DataMapper
   module Types
-    VERSION = '1.3.0.beta'
+    VERSION = '1.2.0'
   end
 end


### PR DESCRIPTION
Before 1.2.2 release please update the spec if you can? Thanks
Try it out. I'm tired of:
Post-install message from bcrypt-ruby:

#######################################################

The bcrypt-ruby gem has changed its name to just bcrypt.  Instead of
installing `bcrypt-ruby`, you should install `bcrypt`.  Please update your
dependencies accordingly.

#######################################################

A work around here:
https://learnsinatrajustdoit.herokuapp.com/
Watch out that I changed the version back to 1.2.0 after pull request.
Also see:
https://learnsinatrajustdoit.herokuapp.com/gemfile
and https://learnsinatrajustdoit.herokuapp.com/gemlock