### PR TITLE
Loosen dependency on multi_json

### DIFF
--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('bcrypt',      '~> 3.0')
   gem.add_runtime_dependency('dm-core',     '~> 1.3.0.beta')
   gem.add_runtime_dependency('fastercsv',   '~> 1.5.4')
-  gem.add_runtime_dependency('multi_json', '>= 1.3.2')
+  gem.add_runtime_dependency('multi_json', '~> 1.3.2')
   gem.add_runtime_dependency('stringex', '>= 2.0.8')
   gem.add_runtime_dependency('safe_yaml',   '~> 0.6.1')
   gem.add_runtime_dependency('uuidtools',   '~> 2.1.2')

--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('bcrypt',      '~> 3.0')
   gem.add_runtime_dependency('dm-core',     '~> 1.3.0.beta')
   gem.add_runtime_dependency('fastercsv',   '~> 1.5.4')
-  gem.add_runtime_dependency('multi_json', '>= 1.7.7')
+  gem.add_runtime_dependency('multi_json', '>= 1.3.2')
   gem.add_runtime_dependency('stringex', '>= 2.0.8')
   gem.add_runtime_dependency('safe_yaml',   '~> 0.6.1')
   gem.add_runtime_dependency('uuidtools',   '~> 2.1.2')

--- a/dm-types.gemspec
+++ b/dm-types.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('bcrypt',      '~> 3.0')
   gem.add_runtime_dependency('dm-core',     '~> 1.3.0.beta')
   gem.add_runtime_dependency('fastercsv',   '~> 1.5.4')
-  gem.add_runtime_dependency('multi_json', '~> 1.3.2')
+  gem.add_runtime_dependency('multi_json', '>= 1.3.2')
   gem.add_runtime_dependency('stringex', '>= 2.0.8')
   gem.add_runtime_dependency('safe_yaml',   '~> 0.6.1')
   gem.add_runtime_dependency('uuidtools',   '~> 2.1.2')


### PR DESCRIPTION
The other datamapper gems depend mostly on multi_json 1.3.2
Example: https://github.com/datamapper/dm-serializer/blob/master/dm-serializer.gemspec

dm-types also depended previously on 1.3.2 https://github.com/datamapper/dm-types/commit/e541869dc05fdd707e8242ec8922873f75e50fc2
